### PR TITLE
Juice dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-juice-email",
   "description": "Inline stylesheets into email HTML templates using LearnBoost's Juice",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/disintegrator/grunt-juice-email",
   "author": {
     "name": "George Haidar",


### PR DESCRIPTION
After installing `grunt-juice-email` and trying to run grunt, I got an error about not finding module 'juice'

``` bash
$ grunt
Loading "juice.js" tasks...ERROR
>> Error: Cannot find module 'juice'
```

So I forked, updated the dependency to be a main dependency, npm installed from the git sha (which included installing juice), and ran again without problem.
