### PR TITLE
Added support for Global settings

### DIFF
--- a/tasks/juice.js
+++ b/tasks/juice.js
@@ -18,6 +18,16 @@ module.exports = function(grunt) {
             done = this.async(),
             jobs = [];
 
+
+        // Juice Global settings
+        if (options.hasOwnProperty("globals")) {
+          for (var key in options.globals) {
+            if (options.globals.hasOwnProperty(key)) {
+                juice[key] = options.globals[key];
+            }
+          }
+        }
+
         // Iterate over all specified file groups.
         this.files.forEach(function(f) {
           // Concat specified files.


### PR DESCRIPTION
Used the option object of grunt with the keyword "globals"

A example of the feature would be the following code, in that way we can override the configuration of Juice.

``` javascript
options: {
      preserveMediaQueries: true,
      applyAttributesTableElements: true,
      applyWidthAttributes: true,
      preserveImportant: true,
      preserveFontFaces: true,
      globals : {
          styleToAttribute : {
                'background-color': 'bgcolor',
                'background-image': 'background',
                'text-align': 'align',
                'vertical-align': 'valign',
                'border': 'border',
                'cellpadding': 'cellpadding'
            }
        }
    }
```
